### PR TITLE
[Finish]MySQL用のDockerコンテナを作成するため、docker-compose.ymlを作成

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,15 @@
+# Use root/example as user/password credentials
+version: '3.1'
+
+services:
+
+  db:
+    image: mysql
+    restart: always
+    environment:
+      MYSQL_ROOT_PASSWORD: example     # rootユーザーのパスワード
+      MYSQL_DATABASE: motocataloguedb  # データベース名
+      MYSQL_USER: develop              # アクセスする際のユーザー名
+      MYSQL_PASSWORD: develop          #アクセスする際のパスワード
+    ports:
+      - 3306:3306  # コンテナ外部からアクセスできるようにする。(MySQLのデフォルトポート番号)


### PR DESCRIPTION
MySQL用のDockerコンテナを作成するために、DockerHubよりdocker-compose.ymlを準備、
不要な設定の削除と必要な設定の変更を実施。

Dockerコンテナの起動を確認。
(SQL操作は外部アプリケーション(A5:SQLを使用)